### PR TITLE
Successful run of txFunction 'recurring' on tss-wrangler and serverless

### DIFF
--- a/serverless/package.json
+++ b/serverless/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "bignumber.js": "^9.0.1",
+    "moment": "^2.29.1",
     "node-fetch": "^2.6.1",
     "stellar-sdk": "^8.2.4"
   },

--- a/serverless/serverless.yml
+++ b/serverless/serverless.yml
@@ -17,6 +17,7 @@ custom:
     includeModules:
       forceInclude:
         - bignumber.js
+        - moment
         - node-fetch
         - stellar-sdk
       forceExclude:
@@ -41,8 +42,7 @@ provider:
 functions:
   run:
     handler: src/app.default
-    # If you're not on a paid plan with AWS you'll need to use 0 (i.e. 'free'), otherwise you'll get an RunLambdaEvConf error
-    provisionedConcurrency: ${self:custom.provisionedConcurrency.${env:SLS_AWS_PLAN}, self:custom.provisionedConcurrency.free}
+    provisionedConcurrency: 1
     memorySize: 256
     timeout: 8
     events:

--- a/serverless/src/app.js
+++ b/serverless/src/app.js
@@ -70,11 +70,7 @@ export default async (event) => {
     // )
     // const result = await txFunction(body)
 
-    const result = await eval(`
-      'use strict'; 
-      ${txFunctionCode};
-      module.exports;
-    `)(body)
+    const result = await invoke(txFunctionCode, body)
 
     return {
       statusCode: 200,
@@ -108,5 +104,13 @@ export default async (event) => {
         status: err.status,
       })
     }
+  }
+  async function invoke (txFunction, body) {
+    const result = eval(`
+      'use strict';
+      ${txFunction};
+      module.exports;
+    `)
+    return await result.txFunction(body);
   }
 }

--- a/wrangler/src/txFunctions/run.js
+++ b/wrangler/src/txFunctions/run.js
@@ -35,7 +35,7 @@ export default async ({ request, params, env, ctx }) => {
   const txFunction = txFunctionBuffer.slice(0, length).toString()
 
   const body = await request.json()
-  const feeToken = request.headers.get('authorization')?.split(' ')?.[1]
+  const feeToken = request.headers.get('authorization')
 
   if (!feeToken)
     throw {message: `feeToken is missing`}


### PR DESCRIPTION
Hi Tyler!

I managed to run your `recurring` txFunction (see below), got an XDR returned:

⚠️  run txFunction 'recurring' on tss-wrangler Cloudflare Worker
- started run
- feeToken `AAAAAgAAAABsUc9AWas49gIfufEwwwytQ824A6IaoGgqvd8Es1YIBgAAAMgAAAAAAAAAAAAAAAEAAAAAYS7CgAAAAABhVk9/AAAAAAAAAAIAAAAAAAAADwAAAAD3XDyrPXD5KR/1PUmYsaALhyrn9EUD1mrhAJZK+XDjggAAAAAAAAAKAAAADnR4RnVuY3Rpb25IYXNoAAAAAAABAAAAQDlmODBlMTExMTJiNTg5MzIxM2FjN2QwZjE5MWE1Nzg3ODViZmUwNGNlZDUzZDBkMTk2MGUxNzdjZTcyZWY2M2UAAAAAAAAAAbNWCAYAAABAqs2m+Mxwk/4Kj+f4pvRsNKbdJSZDRsMhgOiIjj+bDH1lvmfIKGzfa5ce8pCfU5PhMSTjhZ5luTp+T1TtURhpAA==`
- ending run...
- res `{"xdr":"AAAAAgAAAACJS1zb1a61bXde7WTqK7jgfnKcgh+pIVxKH87IaW5K/AAAAMgAEOvDAAAAAgAAAAEAAAAAYS7CgAAAAABhVk9/AAAAAAAAAAIAAAAAAAAAAQAAAAAnBlxmpNLWGfmZGbECtCHWy6As0zQ5yLif7Yhkhl096AAAAAAAAAACVAvkAAAAAAAAAAAKAAAAQHRzcy5HQVRRTVhER1VUSk5NR1BaVEVNM0NBVlVFSExNWElCTTJNMkRUU0ZZVDdXWVFaRUdMVTY2UlRZTC5yYW4AAAABAAAACjE2MzA4NjY0ODAAAAAAAAAAAAAA","signer":"GBJYHNHAEKLC75IRWQGPKPCBTLXFKX4IE6N5XDQ6EQZWXCN3E7RIDLB7","signature":"KB5EjKw7NFzqBStobkKHCPMHr8Xs7qq6N8uyj1U+8GXWOS9v2iG34b+rfeOCJIgtAzExTrIRkMEm4LrZymRDDQ==","cost":"0.0110900"}`

To do so, I made the changes that I am submitting for your review. Please take a look when you have a minute. I had lots of fun with your wonderful stuff and I thank you so much for it!

Cheers,
Alec

```
const { Networks, Asset, BASE_FEE, Operation, TransactionBuilder, Server } = require('stellar-sdk')
const moment = require('moment')

const STELLAR_NETWORK = 'TESTNET'
const HORIZON_URL = 'https://horizon-testnet.stellar.org'
const server = new Server(HORIZON_URL)
const XLM = Asset.native()

const recurring = async request => {
  const destAcct = request.destination
  const ran = `tss.${destAcct}.ran`
  try {
    const transaction = await server
    .loadAccount(request.source)
    .then(account => {
      const lastRanRaw = account.data_attr[ran]
      const now = moment.utc().startOf('minute')
      const minTime = now.clone().startOf('month')
      const maxTime = minTime.clone().endOf('month')

      if (lastRanRaw) {
        const lastRanParsed = Buffer.from(lastRanRaw, 'base64').toString('utf8')
        const lastRanDate = moment.utc(lastRanParsed, 'X')

        if (lastRanDate.startOf('month').isSame(minTime, 'month'))
          throw `It hasn't been a month since the last run`
      }

      const transaction = new TransactionBuilder(account, {
        fee: BASE_FEE,
        timebounds: {
          minTime: minTime.unix(),
          maxTime: maxTime.unix()
        },
        networkPassphrase: Networks[STELLAR_NETWORK]
      })
      .addOperation(Operation.payment({
        destination: destAcct,
        asset: XLM,
        amount: '1000'
      }))
      .addOperation(Operation.manageData({
        name: ran,
        value: now.unix().toString()
      }))
      return transaction
    })

    return transaction.build().toXDR()
  }
  catch(err) {
    throw err
  }
}

exports.txFunction = recurring
```